### PR TITLE
Splitting blow counter

### DIFF
--- a/Encounters.lua
+++ b/Encounters.lua
@@ -3458,6 +3458,7 @@ do
             phase = 1,
 			intermissioncount = 0,
             sonscount = 8,
+            splittingblowcount = 0,
             
             -- Report
             meteor1guid = "",

--- a/Encounters.lua
+++ b/Encounters.lua
@@ -829,7 +829,7 @@ do
             },
             {
                 phase = 1,
-                alerts = {"spinnerscd","spinnerswarn","spiderlingscd","spiderlingswarn","dronescd","droneswarn","fixatewarn","fixateselfwarn","poisonselfwarn","devastationcd","devastationsoon","devastationwarn", flarecd"},
+                alerts = {"spinnerscd","spinnerswarn","spiderlingscd","spiderlingswarn","dronescd","droneswarn","fixatewarn","fixateselfwarn","poisonselfwarn","devastationcd","devastationsoon","devastationwarn", "flarecd"},
             },
             {
                 phase = 2,

--- a/Encounters.lua
+++ b/Encounters.lua
@@ -4479,6 +4479,7 @@ do
 						"batchquash",{"smashcd","trapcd","flamescd","seedcd","handcd","wrathcd"},
                         "alert","splitcast",
                         "set",{intermissioncount = "INCR|1"},
+                        "set",{splittingblowcount= "INCR|1"},
 						"set",{
                             phasetext = format(L.alert["Intermission %s"],"<intermissioncount>"),
                             intermissiontext = format(L.alert["Phase %s"],"&sum|<phase>|1&"),


### PR DESCRIPTION
For this PR I have done the following:

1. Added a missing quotation mark that was preventing DXE from loading the Firelands module.
2. Added a SplittingBlowCounter and initialise with value of 0.
3. Added an increment to the SplittingBlowCounter for when it is cast - used later to determine when the timers for Blazing Heat will show for users.