### PR TITLE
Blazing Heat Initial Timers

### DIFF
--- a/Encounters.lua
+++ b/Encounters.lua
@@ -3683,7 +3683,7 @@ do
             },
             {
                 phase = 3,
-                alerts = {"meteorcd","meteorwarn","meteorselfwarn","fixateselfwarn"},
+                alerts = {"meteorcd","meteorwarn","meteorselfwarn","fixateselfwarn","blazingheatcd","blazingheatwarn",},
             },
             {
                 phase = 4,

--- a/Encounters.lua
+++ b/Encounters.lua
@@ -4005,6 +4005,28 @@ do
             },          
             -- Sons of Flame Dead
             
+            -- Blazing Heat Timers & Warning
+                blazingheatcd = {
+                varname = format(L.alert["%s CD"],SN[100981]),
+                type = "dropdown",
+                text = format(L.alert["Next %s"],SN[100981]),
+                time = "<blazingheatcd>",
+                flashtime = 5,
+                color1 = "RED",
+                icon = ST[100981],
+                },
+            
+                blazingheatwarn = {
+                varname = format(L.alert["%s Warning"],SN[100981]),
+                type = "centerpopup",
+                text = format(L.alert["%s"],SN[100981]),
+                time = 3,
+                flashtime = 3,
+                color1 = "RED",
+                icon = ST[100981],
+                sound = "ALERT2",
+                },
+
             -- Blazing Heat
             heatwarn = {
 				varname = format(L.alert["%s Warning"],SN[100981]),

--- a/Encounters.lua
+++ b/Encounters.lua
@@ -4006,7 +4006,7 @@ do
             -- Sons of Flame Dead
             
             -- Blazing Heat Timers & Warning
-                blazingheatcd = {
+            blazingheatcd = {
                 varname = format(L.alert["%s CD"],SN[100981]),
                 type = "dropdown",
                 text = format(L.alert["Next %s"],SN[100981]),
@@ -4014,9 +4014,9 @@ do
                 flashtime = 5,
                 color1 = "RED",
                 icon = ST[100981],
-                },
-            
-                blazingheatwarn = {
+            },
+        
+            blazingheatwarn = {
                 varname = format(L.alert["%s Warning"],SN[100981]),
                 type = "centerpopup",
                 text = format(L.alert["%s"],SN[100981]),
@@ -4025,7 +4025,7 @@ do
                 color1 = "RED",
                 icon = ST[100981],
                 sound = "ALERT2",
-                },
+            },
 
             -- Blazing Heat
             heatwarn = {

--- a/Encounters.lua
+++ b/Encounters.lua
@@ -3675,7 +3675,7 @@ do
             },
             {
                 phase = format("|cffffd700Intermission|r |cffffffffPhase|r"),
-                alerts = {"intermissionsoonwarn","splitcast","hammersidewarn","intermissionduration","sonkilledwarn","heatwarn","heatselfwarn"},
+                alerts = {"intermissionsoonwarn","splitcast","hammersidewarn","intermissionduration","sonkilledwarn","heatwarn","heatselfwarn","blazingheatcd","blazingheatwarn",},
             },
             {
                 phase = 2,

--- a/Encounters.lua
+++ b/Encounters.lua
@@ -3480,6 +3480,7 @@ do
 				"set",{
 					phase = 1,
                     intermissioncount = 0,
+                    splittingblowcount = 0,
 				},
                 "alert","enragecd",
 				"alert","smashcd",

--- a/Encounters.lua
+++ b/Encounters.lua
@@ -3433,6 +3433,7 @@ do
 			empowercd = {68.3, 56, loop = false, type = "series"},
 			rootscd = {53, 56, loop = false, type = "series"},
             dreadflamecd = {34, 40, 35, 30, 25, 20, 15, loop = false, type = "series"},
+            blazingheatcd = 21,
             
             -- Texts
             heattext = "",


### PR DESCRIPTION
For this PR I have done the following: 

1. Added the initial blazing heat CD for 21 seconds.
2. Added Blazing Heat CD & Warnings
3. Added the Blazing Heat CD & Warnings to the groupings on DXE for the Intermission & P3 phase.
4. Added an initialisation of the Splitting Blow Counter to 0 at the start of the encounter to ensure it resets on wipes.
5. Cleaned up indentations to have it load the Firelands sub-module again.