### PR TITLE
Enable Blazing Heat CD Event Handling

### DIFF
--- a/Encounters.lua
+++ b/Encounters.lua
@@ -4506,6 +4506,14 @@ do
                         "alert","splitcast",
                         "set",{intermissioncount = "INCR|1"},
                         "set",{splittingblowcount= "INCR|1"},
+                        -- Second Intermission Enabling Blazing Heat CD Timer
+                        -- As it's when the initial cast starts, it will just be reoccurring 21s timer
+                        "expect",{"<splittingblowcount>","==","2",}, 
+                        "invoke",{
+                            {
+                                "alert","blazingheatcd",
+                            },
+                        },
 						"set",{
                             phasetext = format(L.alert["Intermission %s"],"<intermissioncount>"),
                             intermissiontext = format(L.alert["Phase %s"],"&sum|<phase>|1&"),


### PR DESCRIPTION
For this PR I have done the following:

1. Added an event listener so when the splitting blow counter reaches 2 it will enable the Blazing Heat CD timer automatically.