### PR TITLE
Blazing Heat Timer - Set Recurring Timer

### DIFF
--- a/Encounters.lua
+++ b/Encounters.lua
@@ -4511,6 +4511,7 @@ do
                         "expect",{"<splittingblowcount>","==","2",}, 
                         "invoke",{
                             {
+								"set",{blazingheatcd = {21,21,21,21, loop = false, type = "series"},},
                                 "alert","blazingheatcd",
                             },
                         },


### PR DESCRIPTION
For this PR I have done the following:

- Set rigid timers of **21, 21, 21, 21** seconds instead of the single Blazing Heat timer of 21s.

**TO TEST**

1. That the timers are recurring 21s for a maximum of 4 timers.
2. That the Lava Scion counter upon reaching 0 - should quash all of the subsequent Blazing Heat timers.